### PR TITLE
NetworkConfigPatcher: add DisableGameLift patch

### DIFF
--- a/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
+++ b/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
@@ -13,6 +13,7 @@ namespace MultiplayerCore.Patchers
         public int? DiscoveryPort { get; set; }
         public int? PartyPort { get; set; }
         public int? MultiplayerPort { get; set; }
+        public bool DisableGameLift { get; set; }
 
         private readonly SiraLog _logger;
 
@@ -34,6 +35,7 @@ namespace MultiplayerCore.Patchers
             MasterServerEndPoint = endPoint;
             MasterServerStatusUrl = statusUrl;
             MaxPartySize = maxPartySize;
+            DisableGameLift = true;
         }
 
         /// <summary>
@@ -45,6 +47,7 @@ namespace MultiplayerCore.Patchers
             MasterServerEndPoint = null;
             MasterServerStatusUrl = null;
             MaxPartySize = null;
+            DisableGameLift = false;
         }
 
         [AffinityPatch(typeof(NetworkConfigSO), nameof(NetworkConfigSO.masterServerEndPoint), AffinityMethodType.Getter)]
@@ -106,6 +109,16 @@ namespace MultiplayerCore.Patchers
 
             __result = (int)MultiplayerPort;
             _logger.Debug($"Patching network config multiplayer port with '{__result}'.");
+        }
+
+        [AffinityPatch(typeof(NetworkConfigSO), nameof(NetworkConfigSO.forceGameLift), AffinityMethodType.Getter)]
+        private void GetForceGameLift(ref bool __result)
+        {
+            if (!DisableGameLift)
+                return;
+
+            __result = false;
+            _logger.Warn($"Patching network config forceGameLift with '{__result}'.");
         }
 
         [AffinityPrefix]

--- a/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
+++ b/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
@@ -118,7 +118,7 @@ namespace MultiplayerCore.Patchers
                 return;
 
             __result = false;
-            _logger.Warn($"Patching network config forceGameLift with '{__result}'.");
+            _logger.Debug($"Patching network config forceGameLift with '{__result}'.");
         }
 
         [AffinityPrefix]


### PR DESCRIPTION
As a precaution, it would be good if MultiplayerCore ensures `forceGameLift` is always turned off whenever it provides a master server override.

Some context as discussed in BT server:

> so at least on PC networkConfig.forceGameLift isn't currently set to true, which is why MpCore/BT can switch servers just fine. I agree though that MultiplayerCore should manage/patch that field whenever it overrides the network config 
> 
> generally speaking, and as it is on PC right now, the status API will tell the game whether it should use GameLift or not in the JSON (use_gamelift) . if GameLift isn't explicitly activated in either the config or the status it will still use a regular master server connection