### PR TITLE
Force master server use if DisableGameLift is set

### DIFF
--- a/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
+++ b/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
@@ -57,6 +57,7 @@ namespace MultiplayerCore.Patchers
                 return;
 
             __result = MasterServerEndPoint;
+            _logger.Debug($"Patching masterServerEndPoint with '{__result}'.");
         }
 
         [AffinityPatch(typeof(NetworkConfigSO), nameof(NetworkConfigSO.multiplayerStatusUrl), AffinityMethodType.Getter)]
@@ -66,6 +67,7 @@ namespace MultiplayerCore.Patchers
                 return;
 
             __result = MasterServerStatusUrl;
+            _logger.Debug($"Patching multiplayerStatusUrl with '{__result}'.");
         }
 
         [AffinityPatch(typeof(NetworkConfigSO), nameof(NetworkConfigSO.maxPartySize), AffinityMethodType.Getter)]
@@ -119,6 +121,17 @@ namespace MultiplayerCore.Patchers
 
             __result = false;
             _logger.Debug($"Patching network config forceGameLift with '{__result}'.");
+        }
+        
+        [AffinityPrefix]
+        [AffinityPatch(typeof(UnifiedNetworkPlayerModel), nameof(UnifiedNetworkPlayerModel.SetActiveNetworkPlayerModelType))]
+        private void PrefixSetActiveNetworkPlayerModelType(ref UnifiedNetworkPlayerModel.ActiveNetworkPlayerModelType activeNetworkPlayerModelType)
+        {
+            if (!DisableGameLift)
+                return;
+
+            activeNetworkPlayerModelType = UnifiedNetworkPlayerModel.ActiveNetworkPlayerModelType.MasterServer;
+            _logger.Debug($"Patching activeNetworkPlayerModelType with '{activeNetworkPlayerModelType}'.");
         }
 
         [AffinityPrefix]


### PR DESCRIPTION
### [Force master server use if DisableGameLift is set](https://github.com/Goobwabber/MultiplayerCore/commit/d6e66e29364b34eb525c3816c1e2902df1267f32)
- This extends the `DisableGameLift` patcher option to always enforce the use of a master server connection when set.
- This patch effectively overrides the `useGameLift` multiplayer status response field. 
- Fixes some specific scenarios where the game would keep connecting to GameLift instead of using MultiplayerCore's patched master server.