### PR TITLE
Expose a couple constructors

### DIFF
--- a/MultiplayerCore/Objects/MpLevelLoader.cs
+++ b/MultiplayerCore/Objects/MpLevelLoader.cs
@@ -17,7 +17,7 @@ namespace MultiplayerCore.Objects
         private readonly IMenuRpcManager _rpcManager;
         private readonly SiraLog _logger;
 
-        internal MpLevelLoader(
+        public MpLevelLoader(
             IMultiplayerSessionManager sessionManager,
             MpLevelDownloader levelDownloader,
             NetworkPlayerEntitlementChecker entitlementChecker,

--- a/MultiplayerCore/Objects/MpPlayersDataModel.cs
+++ b/MultiplayerCore/Objects/MpPlayersDataModel.cs
@@ -16,7 +16,7 @@ namespace MultiplayerCore.Objects
         private readonly MpBeatmapLevelProvider _beatmapLevelProvider;
         private readonly SiraLog _logger;
 
-        internal MpPlayersDataModel(
+        public MpPlayersDataModel(
             MpPacketSerializer packetSerializer,
             MpBeatmapLevelProvider beatmapLevelProvider,
             SiraLog logger)


### PR DESCRIPTION
BeatUpClient needs the ability to override some of MultiplayerCore's injections, which currently have their constructors marked `internal`