### PR TITLE
fix NullReferenceException log spam in MpLoadingIndicator

### DIFF
--- a/MultiplayerCore/Objects/MpLevelLoader.cs
+++ b/MultiplayerCore/Objects/MpLevelLoader.cs
@@ -11,7 +11,7 @@ namespace MultiplayerCore.Objects
     {
         public event Action<double> progressUpdated = null!;
 
-        public ILevelGameplaySetupData CurrentLoadingData => _gameplaySetupData;
+        public ILevelGameplaySetupData? CurrentLoadingData => _gameplaySetupData;
 
         private readonly IMultiplayerSessionManager _sessionManager;
         private readonly MpLevelDownloader _levelDownloader;

--- a/MultiplayerCore/UI/MpLoadingIndicator.cs
+++ b/MultiplayerCore/UI/MpLoadingIndicator.cs
@@ -60,7 +60,7 @@ namespace MultiplayerCore.UI
         {
             if (_isDownloading)
                 return;
-            else if (_screenController.countdownShown && _sessionManager.syncTime >= _gameStateController.startTime && _gameStateController.levelStartInitiated)
+            else if (_screenController.countdownShown && _sessionManager.syncTime >= _gameStateController.startTime && _gameStateController.levelStartInitiated && _levelLoader.CurrentLoadingData != null)
                 _loadingControl.ShowLoading($"{_playersDataModel.Count(x => _entitlementChecker.GetUserEntitlementStatusWithoutRequest(x.Key, _levelLoader.CurrentLoadingData.beatmapLevel.beatmapLevel.levelID) == EntitlementsStatus.Ok)} of {_playersDataModel.Count} players ready...");
             else
                 _loadingControl.Hide();


### PR DESCRIPTION
The loading indicator continues to tick following `MultiplayerLevelLoader.ClearLoading()`, so `MultiplayerLevelLoader._gameplaySetupData` needs to be null checked.