### PR TITLE
Add server controls for movement updates

### DIFF
--- a/MultiplayerCore/Installers/MpAppInstaller.cs
+++ b/MultiplayerCore/Installers/MpAppInstaller.cs
@@ -25,7 +25,7 @@ namespace MultiplayerCore.Installers
             Container.BindInstance(new UBinder<Plugin, BeatSaver>(_beatsaver)).AsSingle();
             Container.BindInterfacesAndSelfTo<MpPacketSerializer>().AsSingle();
             Container.BindInterfacesAndSelfTo<MpPlayerManager>().AsSingle();
-            Container.BindInterfacesAndSelfTo<MpNodePoseStateSyncManager>().AsSingle();
+            Container.BindInterfacesAndSelfTo<MpNodePoseSyncStateManager>().AsSingle();
             Container.Bind<MpLevelDownloader>().ToSelf().AsSingle();
             Container.Bind<MpBeatmapLevelProvider>().ToSelf().AsSingle();
             Container.BindInterfacesAndSelfTo<CustomLevelsPatcher>().AsSingle();

--- a/MultiplayerCore/Installers/MpAppInstaller.cs
+++ b/MultiplayerCore/Installers/MpAppInstaller.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaverSharp;
 using MultiplayerCore.Beatmaps.Providers;
 using MultiplayerCore.Networking;
+using MultiplayerCore.NodePoseSyncState;
 using MultiplayerCore.Objects;
 using MultiplayerCore.Patchers;
 using MultiplayerCore.Players;
@@ -24,6 +25,7 @@ namespace MultiplayerCore.Installers
             Container.BindInstance(new UBinder<Plugin, BeatSaver>(_beatsaver)).AsSingle();
             Container.BindInterfacesAndSelfTo<MpPacketSerializer>().AsSingle();
             Container.BindInterfacesAndSelfTo<MpPlayerManager>().AsSingle();
+            Container.BindInterfacesAndSelfTo<MpNodePoseStateSyncManager>().AsSingle();
             Container.Bind<MpLevelDownloader>().ToSelf().AsSingle();
             Container.Bind<MpBeatmapLevelProvider>().ToSelf().AsSingle();
             Container.BindInterfacesAndSelfTo<CustomLevelsPatcher>().AsSingle();

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -225,6 +225,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="NodePoseSyncState\" />
+  </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="BeforeBuild" Condition="'$(NCRUNCH)' != '1'">
     <Error Text="The BeatSaberModdingTools.Tasks nuget package doesn't seem to be installed." Condition="'$(BSMTTaskAssembly)' == ''" />
     <GetCommitInfo ProjectDir="$(ProjectDir)">

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseStateSyncManager.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseStateSyncManager.cs
@@ -1,0 +1,54 @@
+﻿using MultiplayerCore.Networking;
+using System;
+using Zenject;
+using SiraUtil.Affinity;
+
+
+namespace MultiplayerCore.NodePoseSyncState
+{
+    internal class MpNodePoseStateSyncManager : IInitializable, IDisposable, IAffinity
+    {
+        public float? DeltaUpdateFrequency { get; private set; } = null;
+        public float? FullStateUpdateFrequency { get; private set; } = null;
+
+        private readonly MpPacketSerializer _packetSerializer;
+        MpNodePoseStateSyncManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
+        
+        public void Initialize() => _packetSerializer.RegisterCallback<MpNodePoseSyncStatePacket>(HandleUpdateFrequencyUpdated);
+        
+        public void Dispose() => _packetSerializer.UnregisterCallback<MpNodePoseSyncStatePacket>();
+
+        private void HandleUpdateFrequencyUpdated(MpNodePoseSyncStatePacket data, IConnectedPlayer player)
+        {
+            if (player.isConnectionOwner)
+            {
+                DeltaUpdateFrequency = data.deltaUpdateFrequency;
+                FullStateUpdateFrequency = data.fullStateUpdateFrequency;
+            }
+        }
+
+        [AffinityPrefix]
+        [AffinityPatch(typeof(NodePoseStateSyncManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
+        private bool GetDeltaUpdateFrequency(ref float __result)
+        {
+            if (DeltaUpdateFrequency.HasValue)
+            {
+                __result = DeltaUpdateFrequency.Value;
+                return false;
+            }
+            return true;
+        }
+
+        [AffinityPrefix]
+        [AffinityPatch(typeof(NodePoseStateSyncManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
+        private bool GetFullStateUpdateFrequency(ref float __result)
+        {
+            if (FullStateUpdateFrequency.HasValue)
+            {
+                __result = FullStateUpdateFrequency.Value;
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStateManager.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStateManager.cs
@@ -6,13 +6,13 @@ using SiraUtil.Affinity;
 
 namespace MultiplayerCore.NodePoseSyncState
 {
-    internal class MpNodePoseStateSyncManager : IInitializable, IDisposable, IAffinity
+    internal class MpNodePoseSyncStateManager : IInitializable, IDisposable, IAffinity
     {
         public float? DeltaUpdateFrequency { get; private set; } = null;
         public float? FullStateUpdateFrequency { get; private set; } = null;
 
         private readonly MpPacketSerializer _packetSerializer;
-        MpNodePoseStateSyncManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
+        MpNodePoseSyncStateManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
         
         public void Initialize() => _packetSerializer.RegisterCallback<MpNodePoseSyncStatePacket>(HandleUpdateFrequencyUpdated);
         
@@ -28,7 +28,7 @@ namespace MultiplayerCore.NodePoseSyncState
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(NodePoseStateSyncManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
+        [AffinityPatch(typeof(NodePoseSyncStateManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
         private bool GetDeltaUpdateFrequency(ref float __result)
         {
             if (DeltaUpdateFrequency.HasValue)
@@ -40,7 +40,7 @@ namespace MultiplayerCore.NodePoseSyncState
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(NodePoseStateSyncManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
+        [AffinityPatch(typeof(NodePoseSyncStateManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
         private bool GetFullStateUpdateFrequency(ref float __result)
         {
             if (FullStateUpdateFrequency.HasValue)

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStatePacket.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStatePacket.cs
@@ -1,0 +1,22 @@
+﻿using MultiplayerCore.Networking.Abstractions;
+using LiteNetLib.Utils;
+
+namespace MultiplayerCore.NodePoseSyncState
+{
+    internal class MpNodePoseSyncStatePacket : MpPacket
+    {
+        public float deltaUpdateFrequency = 0.01f;
+        public float fullStateUpdateFrequency = 0.1f;
+        public override void Serialize(NetDataWriter writer)
+        {
+            writer.Put(deltaUpdateFrequency);
+            writer.Put(fullStateUpdateFrequency);
+        }
+
+        public override void Deserialize(NetDataReader reader)
+        {
+            deltaUpdateFrequency = reader.GetFloat();
+            fullStateUpdateFrequency = reader.GetFloat();
+        }
+    }
+}


### PR DESCRIPTION
 - requires a compile test, was not implemented on a machine with modding setup
 - adds MpNodePoseSyncStateManager, allowing server packets to override the player positions updates to be sent less (or more) frequently by the server sending a packet