### PR TITLE
Improvements, fixes, changes 1.30.2

### DIFF
--- a/MultiplayerCore/Installers/MpAppInstaller.cs
+++ b/MultiplayerCore/Installers/MpAppInstaller.cs
@@ -25,7 +25,7 @@ namespace MultiplayerCore.Installers
             Container.BindInstance(new UBinder<Plugin, BeatSaver>(_beatsaver)).AsSingle();
             Container.BindInterfacesAndSelfTo<MpPacketSerializer>().AsSingle();
             Container.BindInterfacesAndSelfTo<MpPlayerManager>().AsSingle();
-            Container.BindInterfacesAndSelfTo<MpNodePoseStateSyncManager>().AsSingle();
+            Container.BindInterfacesAndSelfTo<MpNodePoseSyncStateManager>().AsSingle();
             Container.Bind<MpLevelDownloader>().ToSelf().AsSingle();
             Container.Bind<MpBeatmapLevelProvider>().ToSelf().AsSingle();
             Container.BindInterfacesAndSelfTo<CustomLevelsPatcher>().AsSingle();

--- a/MultiplayerCore/Installers/MpAppInstaller.cs
+++ b/MultiplayerCore/Installers/MpAppInstaller.cs
@@ -1,6 +1,7 @@
 ﻿using BeatSaverSharp;
 using MultiplayerCore.Beatmaps.Providers;
 using MultiplayerCore.Networking;
+using MultiplayerCore.NodePoseSyncState;
 using MultiplayerCore.Objects;
 using MultiplayerCore.Patchers;
 using MultiplayerCore.Players;
@@ -24,6 +25,7 @@ namespace MultiplayerCore.Installers
             Container.BindInstance(new UBinder<Plugin, BeatSaver>(_beatsaver)).AsSingle();
             Container.BindInterfacesAndSelfTo<MpPacketSerializer>().AsSingle();
             Container.BindInterfacesAndSelfTo<MpPlayerManager>().AsSingle();
+            Container.BindInterfacesAndSelfTo<MpNodePoseStateSyncManager>().AsSingle();
             Container.Bind<MpLevelDownloader>().ToSelf().AsSingle();
             Container.Bind<MpBeatmapLevelProvider>().ToSelf().AsSingle();
             Container.BindInterfacesAndSelfTo<CustomLevelsPatcher>().AsSingle();

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -107,7 +107,7 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Main">
+    <Reference Include="Main" Publicize="True">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -222,6 +222,10 @@
       <Version>1.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>MultiplayerCore</AssemblyName>
-    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <AssemblyVersion>1.3.0</AssemblyVersion>
     <TargetFramework>net472</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -43,7 +43,11 @@
     <None Remove="UI\RequirementsUI.bsml" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="BeatmapCore">
+	  <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <Reference Include="BeatmapCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
@@ -102,12 +106,7 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="System.IO.Compression">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\System.IO.Compression.dll</HintPath>
-      <Private>False</Private>
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
-    <Reference Include="Main">
+    <Reference Include="Main" Publicize="true">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -219,7 +218,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
-      <Version>1.3.2</Version>
+      <Version>1.4.3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>MultiplayerCore</AssemblyName>
-    <AssemblyVersion>1.3.0</AssemblyVersion>
+    <AssemblyVersion>1.4.0</AssemblyVersion>
     <TargetFramework>net472</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
@@ -43,11 +43,7 @@
     <None Remove="UI\RequirementsUI.bsml" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	  <Reference Include="BeatmapCore">
+    <Reference Include="BeatmapCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
@@ -106,7 +102,12 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Main" Publicize="true">
+    <Reference Include="System.IO.Compression">
+      <HintPath>$(BeatSaberDir)\Libs\System.IO.Compression.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Main">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -218,14 +219,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
-      <Version>1.4.3</Version>
+      <Version>1.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="NodePoseSyncState\" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="BeforeBuild" Condition="'$(NCRUNCH)' != '1'">
     <Error Text="The BeatSaberModdingTools.Tasks nuget package doesn't seem to be installed." Condition="'$(BSMTTaskAssembly)' == ''" />

--- a/MultiplayerCore/MultiplayerCore.csproj
+++ b/MultiplayerCore/MultiplayerCore.csproj
@@ -225,6 +225,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="NodePoseSyncState\" />
+  </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="BeforeBuild" Condition="'$(NCRUNCH)' != '1'">
     <Error Text="The BeatSaberModdingTools.Tasks nuget package doesn't seem to be installed." Condition="'$(BSMTTaskAssembly)' == ''" />
     <GetCommitInfo ProjectDir="$(ProjectDir)">

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseStateSyncManager.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseStateSyncManager.cs
@@ -1,0 +1,54 @@
+﻿using MultiplayerCore.Networking;
+using System;
+using Zenject;
+using SiraUtil.Affinity;
+
+
+namespace MultiplayerCore.NodePoseSyncState
+{
+    internal class MpNodePoseStateSyncManager : IInitializable, IDisposable, IAffinity
+    {
+        public float? DeltaUpdateFrequency { get; private set; } = null;
+        public float? FullStateUpdateFrequency { get; private set; } = null;
+
+        private readonly MpPacketSerializer _packetSerializer;
+        MpNodePoseStateSyncManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
+        
+        public void Initialize() => _packetSerializer.RegisterCallback<MpNodePoseSyncStatePacket>(HandleUpdateFrequencyUpdated);
+        
+        public void Dispose() => _packetSerializer.UnregisterCallback<MpNodePoseSyncStatePacket>();
+
+        private void HandleUpdateFrequencyUpdated(MpNodePoseSyncStatePacket data, IConnectedPlayer player)
+        {
+            if (player.isConnectionOwner)
+            {
+                DeltaUpdateFrequency = data.deltaUpdateFrequency;
+                FullStateUpdateFrequency = data.fullStateUpdateFrequency;
+            }
+        }
+
+        [AffinityPrefix]
+        [AffinityPatch(typeof(NodePoseStateSyncManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
+        private bool GetDeltaUpdateFrequency(ref float __result)
+        {
+            if (DeltaUpdateFrequency.HasValue)
+            {
+                __result = DeltaUpdateFrequency.Value;
+                return false;
+            }
+            return true;
+        }
+
+        [AffinityPrefix]
+        [AffinityPatch(typeof(NodePoseStateSyncManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
+        private bool GetFullStateUpdateFrequency(ref float __result)
+        {
+            if (FullStateUpdateFrequency.HasValue)
+            {
+                __result = FullStateUpdateFrequency.Value;
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStateManager.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStateManager.cs
@@ -6,13 +6,13 @@ using SiraUtil.Affinity;
 
 namespace MultiplayerCore.NodePoseSyncState
 {
-    internal class MpNodePoseStateSyncManager : IInitializable, IDisposable, IAffinity
+    internal class MpNodePoseSyncStateManager : IInitializable, IDisposable, IAffinity
     {
         public float? DeltaUpdateFrequency { get; private set; } = null;
         public float? FullStateUpdateFrequency { get; private set; } = null;
 
         private readonly MpPacketSerializer _packetSerializer;
-        MpNodePoseStateSyncManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
+        MpNodePoseSyncStateManager(MpPacketSerializer packetSerializer) => _packetSerializer = packetSerializer;
         
         public void Initialize() => _packetSerializer.RegisterCallback<MpNodePoseSyncStatePacket>(HandleUpdateFrequencyUpdated);
         
@@ -28,7 +28,7 @@ namespace MultiplayerCore.NodePoseSyncState
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(NodePoseStateSyncManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
+        [AffinityPatch(typeof(NodePoseSyncStateManager), "deltaUpdateFrequency", AffinityMethodType.Getter)]
         private bool GetDeltaUpdateFrequency(ref float __result)
         {
             if (DeltaUpdateFrequency.HasValue)
@@ -40,7 +40,7 @@ namespace MultiplayerCore.NodePoseSyncState
         }
 
         [AffinityPrefix]
-        [AffinityPatch(typeof(NodePoseStateSyncManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
+        [AffinityPatch(typeof(NodePoseSyncStateManager), "fullStateUpdateFrequency", AffinityMethodType.Getter)]
         private bool GetFullStateUpdateFrequency(ref float __result)
         {
             if (FullStateUpdateFrequency.HasValue)

--- a/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStatePacket.cs
+++ b/MultiplayerCore/NodePoseSyncState/MpNodePoseSyncStatePacket.cs
@@ -1,0 +1,22 @@
+﻿using MultiplayerCore.Networking.Abstractions;
+using LiteNetLib.Utils;
+
+namespace MultiplayerCore.NodePoseSyncState
+{
+    internal class MpNodePoseSyncStatePacket : MpPacket
+    {
+        public float deltaUpdateFrequency = 0.01f;
+        public float fullStateUpdateFrequency = 0.1f;
+        public override void Serialize(NetDataWriter writer)
+        {
+            writer.Put(deltaUpdateFrequency);
+            writer.Put(fullStateUpdateFrequency);
+        }
+
+        public override void Deserialize(NetDataReader reader)
+        {
+            deltaUpdateFrequency = reader.GetFloat();
+            fullStateUpdateFrequency = reader.GetFloat();
+        }
+    }
+}

--- a/MultiplayerCore/Objects/MpEntitlementChecker.cs
+++ b/MultiplayerCore/Objects/MpEntitlementChecker.cs
@@ -34,7 +34,7 @@ namespace MultiplayerCore.Objects
             _logger = logger;
         }
 
-        public override void Start()
+        public new void Start()
         {
             base.Start();
 
@@ -43,7 +43,7 @@ namespace MultiplayerCore.Objects
             _rpcManager.setIsEntitledToLevelEvent += HandleSetIsEntitledToLevel;
         }
 
-        public override void OnDestroy()
+        public new void OnDestroy()
         {
             _rpcManager.getIsEntitledToLevelEvent -= HandleGetIsEntitledToLevel;
             _rpcManager.getIsEntitledToLevelEvent += base.HandleGetIsEntitledToLevel;
@@ -81,7 +81,7 @@ namespace MultiplayerCore.Objects
         /// </summary>
         /// <param name="levelId">Level to check entitlement</param>
         /// <returns>Level entitlement status</returns>
-        public override Task<EntitlementsStatus> GetEntitlementStatus(string levelId)
+        public new Task<EntitlementsStatus> GetEntitlementStatus(string levelId)
         {
             //_logger.Debug($"Checking level entitlement for '{levelId}'");
 

--- a/MultiplayerCore/Objects/MpLevelLoader.cs
+++ b/MultiplayerCore/Objects/MpLevelLoader.cs
@@ -33,7 +33,7 @@ namespace MultiplayerCore.Objects
             _logger = logger;
         }
 
-        public override void LoadLevel(ILevelGameplaySetupData gameplaySetupData, float initialStartTime)
+        public new void LoadLevel(ILevelGameplaySetupData gameplaySetupData, float initialStartTime)
         {
             string levelHash = Utilities.HashForLevelID(gameplaySetupData.beatmapLevel.beatmapLevel.levelID);
             _logger.Debug($"Loading level {gameplaySetupData.beatmapLevel.beatmapLevel.levelID}");
@@ -42,7 +42,7 @@ namespace MultiplayerCore.Objects
                 _getBeatmapLevelResultTask = DownloadBeatmapLevelAsync(gameplaySetupData.beatmapLevel.beatmapLevel.levelID, _getBeatmapCancellationTokenSource.Token);
         }
 
-        public override void Tick()
+        public new void Tick()
         {
             if (_loaderState == MultiplayerBeatmapLoaderState.LoadingBeatmap)
             {

--- a/MultiplayerCore/Objects/MpPlayersDataModel.cs
+++ b/MultiplayerCore/Objects/MpPlayersDataModel.cs
@@ -26,7 +26,7 @@ namespace MultiplayerCore.Objects
             _logger = logger;
         }
 
-        public override void Activate()
+        public new void Activate()
         {
             _packetSerializer.RegisterCallback<MpBeatmapPacket>(HandleMpexBeatmapPacket);
             base.Activate();
@@ -36,7 +36,7 @@ namespace MultiplayerCore.Objects
             _menuRpcManager.recommendBeatmapEvent += this.HandleMenuRpcManagerRecommendBeatmap;
         }
 
-        public override void Deactivate()
+        public new void Deactivate()
         {
             _packetSerializer.UnregisterCallback<MpBeatmapPacket>();
             _menuRpcManager.getRecommendedBeatmapEvent -= this.HandleMenuRpcManagerGetRecommendedBeatmap;
@@ -57,7 +57,7 @@ namespace MultiplayerCore.Objects
             base.SetPlayerBeatmapLevel(player.userId, new PreviewDifficultyBeatmap(preview, characteristic, packet.difficulty));
         }
 
-        public override void HandleMenuRpcManagerGetRecommendedBeatmap(string userId)
+        public new void HandleMenuRpcManagerGetRecommendedBeatmap(string userId)
         {
             ILobbyPlayerData localPlayerData = _playersData[localUserId];
             string? levelId = localPlayerData.beatmapLevel?.beatmapLevel?.levelID;
@@ -70,14 +70,14 @@ namespace MultiplayerCore.Objects
             base.HandleMenuRpcManagerGetRecommendedBeatmap(userId);
         }
 
-        public override void HandleMenuRpcManagerRecommendBeatmap(string userId, BeatmapIdentifierNetSerializable beatmapId)
+        public new void HandleMenuRpcManagerRecommendBeatmap(string userId, BeatmapIdentifierNetSerializable beatmapId)
         {
             if (!string.IsNullOrEmpty(Utilities.HashForLevelID(beatmapId.levelID)))
                 return;
             base.HandleMenuRpcManagerRecommendBeatmap(userId, beatmapId);
         }
 
-        public override async void SetLocalPlayerBeatmapLevel(PreviewDifficultyBeatmap beatmapLevel)
+        public new async void SetLocalPlayerBeatmapLevel(PreviewDifficultyBeatmap beatmapLevel)
         {
             _logger.Debug($"Local player selected song '{beatmapLevel.beatmapLevel.levelID}'");
             string? levelHash = Utilities.HashForLevelID(beatmapLevel.beatmapLevel.levelID);

--- a/MultiplayerCore/Players/MpPlayerData.cs
+++ b/MultiplayerCore/Players/MpPlayerData.cs
@@ -1,4 +1,5 @@
-﻿using LiteNetLib.Utils;
+﻿using Hive.Versioning;
+using LiteNetLib.Utils;
 using MultiplayerCore.Networking.Abstractions;
 using System.Collections.Generic;
 
@@ -16,16 +17,23 @@ namespace MultiplayerCore.Players
         /// </summary>
         public Platform Platform { get; set; }
 
+        /// <summary>
+        /// Version
+        /// </summary>
+        public Version GameVersion { get; set; }
+
         public override void Serialize(NetDataWriter writer)
         {
             writer.Put(PlatformId);
             writer.Put((int)Platform);
+            writer.Put(GameVersion.ToString());
         }
 
         public override void Deserialize(NetDataReader reader)
         {
             PlatformId = reader.GetString();
             Platform = (Platform)reader.GetInt();
+            GameVersion = Version.Parse(reader.GetString());
         }
     }
 

--- a/MultiplayerCore/Players/MpPlayerManager.cs
+++ b/MultiplayerCore/Players/MpPlayerManager.cs
@@ -16,16 +16,13 @@ namespace MultiplayerCore.Players
         private ConcurrentDictionary<string, MpPlayerData> _playerData = new();
 
         private readonly MpPacketSerializer _packetSerializer;
-        private readonly IPlatformUserModel _platformUserModel;
         private readonly IMultiplayerSessionManager _sessionManager;
 
         internal MpPlayerManager(
             MpPacketSerializer packetSerializer,
-            IPlatformUserModel platformUserModel,
             IMultiplayerSessionManager sessionManager)
         {
             _packetSerializer = packetSerializer;
-            _platformUserModel = platformUserModel;
             _sessionManager = sessionManager;
         }
 
@@ -33,29 +30,11 @@ namespace MultiplayerCore.Players
         {
             _sessionManager.SetLocalPlayerState("modded", true);
             _packetSerializer.RegisterCallback<MpPlayerData>(HandlePlayerData);
-            _localPlayerInfo = await _platformUserModel.GetUserInfo();
-            _sessionManager.playerConnectedEvent += HandlePlayerConnected;
         }
 
         public void Dispose()
         {
             _packetSerializer.UnregisterCallback<MpPlayerData>();
-        }
-
-        private void HandlePlayerConnected(IConnectedPlayer player)
-        {
-            _sessionManager.Send(new MpPlayerData
-            {
-                PlatformId = _localPlayerInfo.platformUserId,
-                Platform = _localPlayerInfo.platform switch
-                {
-                    UserInfo.Platform.Test => Platform.Unknown,
-                    UserInfo.Platform.Steam => Platform.Steam,
-                    UserInfo.Platform.Oculus => Platform.OculusPC,
-                    UserInfo.Platform.PS4 => Platform.PS4,
-                    _ => throw new NotImplementedException()
-                }
-            });
         }
 
         private void HandlePlayerData(MpPlayerData packet, IConnectedPlayer player)

--- a/MultiplayerCore/UI/ColorsUI.bsml
+++ b/MultiplayerCore/UI/ColorsUI.bsml
@@ -1,9 +1,9 @@
 ﻿<modal id='modal' anchor-pos-x='-5' anchor-pos-y='5' clickerino-offerino-closerino='false' size-delta-x='85'
 	   size-delta-y='30' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <vertical horizontal-fit='PreferredSize' pref-width='80'>
-		<checkbox-setting text='Allow Custom Song Note Colors' value='noteColors' hover-hint='Allow Custom Songs to override note colors' apply-on-change='true' bind-value='true' />
-		<checkbox-setting text='Allow Custom Song Obstacle Colors' value='obstacleColors' hover-hint='Allow Custom Songs to override wall colors' apply-on-change='true' bind-value='true' />
-		<checkbox-setting text='Allow Custom Song Environment Colors' value='environmentColors' hover-hint='Allow Custom Songs to override light colors' apply-on-change='true' bind-value='true' />
+		<checkbox-setting id='noteColorsToggle' text='Allow Custom Song Note Colors' value='noteColors' hover-hint='Allow Custom Songs to override note colors' apply-on-change='true' bind-value='true' />
+		<checkbox-setting id='obstacleColorsToggle' text='Allow Custom Song Obstacle Colors' value='obstacleColors' hover-hint='Allow Custom Songs to override wall colors' apply-on-change='true' bind-value='true' />
+		<checkbox-setting id='environmentColorsToggle' text='Allow Custom Song Environment Colors' value='environmentColors' hover-hint='Allow Custom Songs to override light colors' apply-on-change='true' bind-value='true' />
 		<horizontal spacing='-5'>
             <text text='Selected Custom Song&#39;s Colors' italics='true' />
 			<background id='selected-color' />

--- a/MultiplayerCore/UI/ColorsUI.bsml
+++ b/MultiplayerCore/UI/ColorsUI.bsml
@@ -1,9 +1,12 @@
 ﻿<modal id='modal' anchor-pos-x='-5' anchor-pos-y='5' clickerino-offerino-closerino='false' size-delta-x='85'
-       size-delta-y='25' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+	   size-delta-y='30' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
     <vertical horizontal-fit='PreferredSize' pref-width='80'>
-        <checkbox-setting text='Allow Custom Song Colors' value='colors' hover-hint='Allow Custom Songs to override note, obstacle and environment colors.' apply-on-change='true' bind-value='true' />
-        <horizontal id='selected-color' spacing='-5'>
+		<checkbox-setting text='Allow Custom Song Note Colors' value='noteColors' hover-hint='Allow Custom Songs to override note colors' apply-on-change='true' bind-value='true' />
+		<checkbox-setting text='Allow Custom Song Obstacle Colors' value='obstacleColors' hover-hint='Allow Custom Songs to override wall colors' apply-on-change='true' bind-value='true' />
+		<checkbox-setting text='Allow Custom Song Environment Colors' value='environmentColors' hover-hint='Allow Custom Songs to override light colors' apply-on-change='true' bind-value='true' />
+		<horizontal spacing='-5'>
             <text text='Selected Custom Song&#39;s Colors' italics='true' />
+			<background id='selected-color' />
         </horizontal>
     </vertical>
 </modal>

--- a/MultiplayerCore/UI/MpColorsUI.cs
+++ b/MultiplayerCore/UI/MpColorsUI.cs
@@ -36,11 +36,25 @@ namespace MultiplayerCore.UI
         [UIComponent("selected-color")]
         private readonly RectTransform selectedColorTransform = null!;
 
-        [UIValue("colors")]
-        public bool Colors
+        [UIValue("noteColors")]
+        public bool NoteColors
         {
-            get => SongCoreConfig.AnyCustomSongColors;
-            set => SongCoreConfig.AnyCustomSongColors = value;
+            get => SongCoreConfig.CustomSongNoteColors;
+            set => SongCoreConfig.CustomSongNoteColors = value;
+        }
+
+        [UIValue("obstacleColors")]
+        public bool ObstacleColors
+        {
+            get => SongCoreConfig.CustomSongObstacleColors;
+            set => SongCoreConfig.CustomSongObstacleColors = value;
+        }
+
+        [UIValue("environmentColors")]
+        public bool EnvironmentColors
+        {
+            get => SongCoreConfig.CustomSongEnvironmentColors;
+            set => SongCoreConfig.CustomSongEnvironmentColors = value;
         }
 
         internal void ShowColors(DifficultyColors colors)

--- a/MultiplayerCore/UI/MpColorsUI.cs
+++ b/MultiplayerCore/UI/MpColorsUI.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using BeatSaberMarkupLanguage;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
+using BeatSaberMarkupLanguage.Components.Settings;
 using HMUI;
 using MultiplayerCore.Beatmaps.Abstractions;
 using MultiplayerCore.Helpers;
@@ -21,6 +22,15 @@ namespace MultiplayerCore.UI
         private readonly Color voidColor = new Color(0.5f, 0.5f, 0.5f, 0.25f);
 
         private readonly LobbySetupViewController _lobbySetupViewController;
+
+        [UIComponent("noteColorsToggle")]
+        private ToggleSetting noteColorToggle;
+
+        [UIComponent("environmentColorsToggle")]
+        private ToggleSetting environmentColorToggle;
+
+        [UIComponent("obstacleColorsToggle")]
+        private ToggleSetting obstacleColorsToggle;
 
         internal MpColorsUI(
             LobbySetupViewController lobbySetupViewController)
@@ -62,6 +72,11 @@ namespace MultiplayerCore.UI
             Parse();
             _modal.Show(true);
             SetColors(colors);
+
+            // We do this to apply any changes to the toggles that might have been made from within SongCores UI
+            noteColorToggle.Value = SongCoreConfig.CustomSongNoteColors;
+            obstacleColorsToggle.Value = SongCoreConfig.CustomSongObstacleColors;
+            environmentColorToggle.Value = SongCoreConfig.CustomSongEnvironmentColors;
         }
 
         private void Parse()

--- a/MultiplayerCore/UI/MpLoadingIndicator.cs
+++ b/MultiplayerCore/UI/MpLoadingIndicator.cs
@@ -61,7 +61,7 @@ namespace MultiplayerCore.UI
             if (_isDownloading)
                 return;
             else if (_screenController.countdownShown && _sessionManager.syncTime >= _gameStateController.startTime && _gameStateController.levelStartInitiated && _levelLoader.CurrentLoadingData != null)
-                _loadingControl.ShowLoading($"{_playersDataModel.Count(x => _entitlementChecker.GetUserEntitlementStatusWithoutRequest(x.Key, _levelLoader.CurrentLoadingData.beatmapLevel.beatmapLevel.levelID) == EntitlementsStatus.Ok)} of {_playersDataModel.Count} players ready...");
+                _loadingControl.ShowLoading($"{_playersDataModel.Count(x => _entitlementChecker.GetUserEntitlementStatusWithoutRequest(x.Key, _levelLoader.CurrentLoadingData.beatmapLevel.beatmapLevel.levelID) == EntitlementsStatus.Ok) + 1} of {_playersDataModel.Count - 1} players ready...");
             else
                 _loadingControl.Hide();
         }

--- a/MultiplayerCore/manifest.json
+++ b/MultiplayerCore/manifest.json
@@ -3,15 +3,17 @@
   "id": "MultiplayerCore",
   "name": "MultiplayerCore",
   "author": "Goobwabber",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Adds custom songs to Beat Saber Multiplayer.",
-  "gameVersion": "1.29.0",
+  "gameVersion": "1.30.2",
   "dependsOn": {
-    "BSIPA": "^4.1.4",
-    "SongCore": "^3.10.1",
-    "BeatSaverSharp": "^3.0.1",
-    "SiraUtil": "^3.0.0",
-    "BeatSaberMarkupLanguage": "^1.6.3"
+    "BSIPA": "^4.3.0",
+    "SongCore": "^3.10.3",
+    "BeatSaverSharp": "^3.4.4",
+    "SiraUtil": "^3.1.3",
+    "BeatSaberMarkupLanguage": "^1.7.3",
+    "System.IO.Compression": "^4.6.0",
+    "System.IO.Compression.FileSystem": "^4.7.0"
   },
   "links": {
     "project-home": "https://github.com/Goobwabber/MultiplayerCore",


### PR DESCRIPTION
This PR adds several changes and improvements

1. Update the toggles for ColorsUI as well as fix the UI layout
2. Sync ColorsUI toggle state with SongCore
3. Disable Avatat Pose Restrictions
4. Scale CenterStateScreen for larger lobbies
5. Changes to MpPlayerData packet, being supplied by the server in the near feature, no longer sent by client
6. Fix numbers for MpLoadingIndicator not showing the correct amount of players as ready and wrong totals
7. Allow the server to control movement updates being sent
8. Added BepInEx.AssemblyPublicizer.MSBuild to project and set Publicize for the main dll ref