### PR TITLE
Allow custom servers when using DisableSsl=false

### DIFF
--- a/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
+++ b/MultiplayerCore/Patchers/NetworkConfigPatcher.cs
@@ -164,11 +164,10 @@ namespace MultiplayerCore.Patchers
         [AffinityPatch(typeof(IgnoranceClient), "Start")]
         private void PrefixIgnoranceClientStart(IgnoranceClient __instance)
         {
-            if (!DisableSsl)
-                return;
-            
-            __instance.UseSsl = false;
-            __instance.ValidateCertificate = false;
+            if (DisableSsl)
+                __instance.UseSsl = false;
+            if (IsOverridingApi)
+                __instance.ValidateCertificate = false;
         }
     }
 }


### PR DESCRIPTION
Fixes a regression introduced during the migration to ENet that broke PC BeatTogether clients connecting to BeatUpServer instances